### PR TITLE
Support for process id as a special argument

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 
 AM_CFLAGS = \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \
+	-lm \
 	$(NULL)
 
 AM_LIBS = \

--- a/README
+++ b/README
@@ -13,13 +13,13 @@ make
 sudo make install
 
 facron configuration file is "/etc/facron.conf".
-You can put as much entries as you want in this file, one entry per line.
+You can put as many entries as you want in this file, one entry per line.
 Each line must be formatted like this:
 
 <file path> <fanotify masks> <command>
 
-Each time an event matching the fanotify masks i sent regarding the file path given
-the command is launched
+Each time an event matching the fanotify masks on the file path given the
+command is launched.
 
 The fanotify masks available are:
 
@@ -42,15 +42,16 @@ If you configure your fanotify masks like this:
 
     FAN_MODIFY|FAN_CLOSE_WRITE,FAN_OPEN
 
-The event caught will be: either FAN_MODIFY AND FAN_CLOSE_WRITE, or FAN_OPEN
+The event caught will be either FAN_MODIFY AND FAN_CLOSE_WRITE, or FAN_OPEN
 
 The command should be an absolute path. You can pass it arguments.
-If any of your arguments contain sapces, you can surrond it with quotes or double quotes.
-Three special arguments are available:
+If any of your arguments contain sapces, you can surround it with quotes or double quotes.
+Four special arguments are available:
 
     $@ corresponds to the dirname of your file
     $# corresponds to the basename of your file
     $$ corresponds to the full path of your file
+    $* corresponds to the process id that accessed the path
 
 You can reload the configuration at any time by sending a SIGUSR1 to facron:
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([facron],[0.9],[Marc-Antoine@Perennou.com])
+AC_CHECK_LIB(m, log10)
 
 PKGCONFIG_REQUIRED="0.22"
 

--- a/man/8/facron.8
+++ b/man/8/facron.8
@@ -32,14 +32,14 @@ facron is a tool to watch your filesystem's changes and react to events.
 .SH "CONFIGURATION"
 facron configuration file is "/etc/facron.conf".
 
-You can put as much entries as you want in this file, one entry per line.
+You can put as many entries as you want in this file, one entry per line.
 
 Each line must be formatted like this:
 
     <file path> <fanotify masks> <command>
 
-Each time an event matching the fanotify masks i sent regarding the file path given
-the command is launched
+Each time an event matching the fanotify masks on the file path given the
+command is launched.
 
 The fanotify masks available are:
 
@@ -62,18 +62,20 @@ If you configure your fanotify masks like this:
 
     FAN_MODIFY|FAN_CLOSE_WRITE,FAN_OPEN
 
-The event caught will be: either FAN_MODIFY AND FAN_CLOSE_WRITE, or FAN_OPEN
+The event caught will be either FAN_MODIFY AND FAN_CLOSE_WRITE, or FAN_OPEN
 
 The command should be an absolute path. You can pass it arguments.
 
-If any of your arguments contain sapces, you can surrond it with quotes or double quotes.
+If any of your arguments contain spaces, you can surround it with quotes or double quotes.
 
-Three special arguments are available:
+Four special arguments are available:
 
     $@ corresponds to the dirname of your file
     $# corresponds to the basename of your file
     $$ corresponds to the full path of your file
+    $* corresponds to the process id that accessed the path
 
 You can reload the configuration at any time by sending a SIGUSR1 to facron:
 
     kill -USR1 $(pidof facron)
+

--- a/src/facron/facron-conf-entry.c
+++ b/src/facron/facron-conf-entry.c
@@ -25,7 +25,7 @@ void
 facron_conf_entry_free (FacronConfEntry *entry, bool follow)
 {
     free (entry->path);
-    for (int i = 0; i < 512 && entry->command[i]; ++i)
+    for (int i = 0; i < MAX_CMD_LEN && entry->command[i]; ++i)
         free (entry->command[i]);
     if (follow && entry->next)
         facron_conf_entry_free (entry->next, true);

--- a/src/facron/facron-conf-entry.h
+++ b/src/facron/facron-conf-entry.h
@@ -21,6 +21,7 @@
 #define __FACRON_CONF_ENTRY_H__
 
 #include <stdbool.h>
+#include "facron.h"
 
 typedef struct FacronConfEntry FacronConfEntry;
 
@@ -28,8 +29,8 @@ struct FacronConfEntry
 {
     FacronConfEntry *next;
     char *path;
-    unsigned long long mask[512];
-    char *command[512];
+    unsigned long long mask[MAX_MASK_LEN];
+    char *command[MAX_CMD_LEN];
 };
 
 void facron_conf_entry_free (FacronConfEntry *entry, bool follow);

--- a/src/facron/facron-conf.c
+++ b/src/facron/facron-conf.c
@@ -32,8 +32,6 @@ facron_conf_load (FacronConf *conf)
     if (!facron_parser_reload (conf->parser))
         return false;
 
-    fprintf (stderr, "Notice: loading configuration\n");
-
     for (FacronConfEntry *entry; (entry = facron_parser_parse_entry (conf->parser)); conf->entries = entry);
 
     return true;
@@ -72,6 +70,8 @@ facron_conf_free (FacronConf *conf)
 FacronConf *
 facron_conf_new (const char *filename)
 {
+    fprintf (stderr, "Notice: loading configuration from %s\n", filename);
+
     FacronConf *conf = (FacronConf *) malloc (sizeof (FacronConf));
 
     conf->parser = facron_parser_new (filename);

--- a/src/facron/facron.h
+++ b/src/facron/facron.h
@@ -1,0 +1,3 @@
+#define MAX_CMD_LEN 512
+#define MAX_MASK_LEN 512
+


### PR DESCRIPTION
The fanotify API includes support for the process id of the process affecting a path. I've added a special argument ($*) that can be used when calling the external command that is populated with the process id.

Note: I'm not a C programmer so my type conversion and changes to the autoconf configuration may not be the most efficient.
